### PR TITLE
Resolved: UITableView did-select event not calling

### DIFF
--- a/BottomSheetController/BottomSheetController/BottomSheet/BottomSheetTransitioningDelegate.swift
+++ b/BottomSheetController/BottomSheetController/BottomSheet/BottomSheetTransitioningDelegate.swift
@@ -103,7 +103,12 @@ final class BottomSheetPresentationController: UIPresentationController {
     let sheetSizingFactor: CGFloat
     let sheetBackdropColor: UIColor
 
-    private(set) lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onTap))
+    private(set) lazy var tapGestureRecognizer: UITapGestureRecognizer = {
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(onTap))
+        gesture.cancelsTouchesInView = false
+        return gesture
+    }()
+    
     private lazy var panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(onPan))
     var panToDismissEnabled: Bool = true
 


### PR DESCRIPTION
While we use tableview inside the bottom sheet and tapToDismissEnabled = true, I was not getting the did-select event of the tableview because our parent view (bottom sheet) has a gesture recognizer. So I told the gesture recognizer to stop canceling child touch events by making cancelsTouchesInView false.